### PR TITLE
Change default behavior of ban command

### DIFF
--- a/commands/ban.js
+++ b/commands/ban.js
@@ -18,7 +18,7 @@ async function execute (ignore, message, args) {
 	message.mentions.members.forEach(async (member) => {
 		if (member.hasPermission(`BAN_MEMBERS`)) return memberSamePermissions(message.channel);
 
-		await member.ban({ days: 7, reason: args.slice(message.mentions.members.size).join(` `) });
+		await member.ban({ days: 0, reason: args.slice(message.mentions.members.size).join(` `) });
 		return successful(message.channel);
 	});
 }


### PR DESCRIPTION
The ban command should not delete messages by default this should be an optional argument.